### PR TITLE
fix: remove alias

### DIFF
--- a/jx-app-flagger/requirements.yaml
+++ b/jx-app-flagger/requirements.yaml
@@ -1,9 +1,7 @@
 dependencies:
 - name: flagger
   repository: "@flagger"
-  alias: flaggerrepo
   version: 0.27.0
 - name: grafana
   repository: "@flagger"
-  alias: flaggerrepo
   version: 1.4.0


### PR DESCRIPTION
## summary

I seem to have hit Helm BUG.

When I use `heml template` command, I got:
```
Error: render error in "jx-app-flagger/charts/flaggerrepo/templates/rbac.yaml": template: jx-app-flagger/charts/flaggerrepo/templates/rbac.yaml:5:20: executing "jx-app-flagger/charts/flaggerrepo/templates/rbac.yaml" at <{{template "flagger.fullname" .}}>: template "flagger.fullname" not defined
```

It works fine when I remove `alias` from `requirements.yaml`.

## reproduce

```
helm fetch --untar --untardir . jenkinsxio/jx-app-flagger 
helm template --name jx-jx-app-flagger --namespace jx ./jx-app-flagger --debug     
```